### PR TITLE
Update Quick Search Docs for 1.3.0 to use new async fetchItems API

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     },
     "license": "MIT",
     "dependencies": {
-        "com.unity.quicksearch": "1.2.8-preview"
+        "com.unity.quicksearch": "1.3.0-preview"
     }
 }


### PR DESCRIPTION
In Quick Search 1.3.0, fetchItems now need to return an IEnumerable<SearchItem> to work with async results. I updated this quicksearch doc extension to support this new API.

Quick Search 1.3.0 should be released by the end of day (7/12/2019)